### PR TITLE
feature/singleton: Move Discord initialization to its own file

### DIFF
--- a/api/client.js
+++ b/api/client.js
@@ -1,0 +1,32 @@
+import { Client, Intents } from "discord.js";
+
+const instance = new Client({ intents: [Intents.FLAGS.GUILDS] });
+
+// Indicates that discord is in the process of creating a new connection
+let initializing = false;
+
+// Opens a new connection with discord if one doesn't exist
+// Returns a Promise<Client>
+// this promise resolves immediately if discord has been initialized and it's ready
+// otherwise it will wait until the client is ready
+export const getDiscordClient = () => {
+    // the caller could destroy the client at any moment
+    // this handles gracefully whether it's ready or not
+    if (instance.isReady()) {
+        return Promise.resolve(instance);
+    }
+
+    if (!initializing) {
+        // handle concurrent calls
+        initializing = true;
+        instance.login().then(() => {
+            initializing = false;
+        });
+    }
+
+    return new Promise((resolve) => {
+        instance.on("ready", () => {
+            resolve(instance);
+        });
+    });
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,7 +1,9 @@
 import { Leetcode } from "./leetcode.js";
 import { Stats } from "./stats.js";
+import { getDiscordClient } from "./client.js";
 
 export {
     Leetcode,
     Stats,
+    getDiscordClient,
 };

--- a/app.js
+++ b/app.js
@@ -11,8 +11,7 @@ import {
 } from "discord-interactions";
 import { config } from "./config.js";
 import {
-    VerifyDiscordRequest, getRandomEmoji, DiscordRequest,
-    initializeDiscordClient, postDailyMessages, postWeeklyMessages,
+    VerifyDiscordRequest, getRandomEmoji, DiscordRequest, postDailyMessages, postWeeklyMessages,
 } from "./utils.js";
 import { getShuffledOptions, getResult } from "./game.js";
 import {
@@ -34,7 +33,6 @@ const activeGames = {};
 /**
  * Client commands that run recurrently (Crons)
  */
-initializeDiscordClient();
 const daily = new CronJob(
     "30 0 0 * * *",
     postDailyMessages,

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,6 @@
 import fetch from "node-fetch";
 import { verifyKey } from "discord-interactions";
-import { Client, Intents } from "discord.js";
-import { Leetcode, Stats } from "./api/index.js";
+import { Leetcode, Stats, getDiscordClient } from "./api/index.js";
 import { config } from "./config.js";
 
 export function VerifyDiscordRequest(clientKey) {
@@ -52,43 +51,24 @@ export function capitalize(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-const discordClient = new Client({ intents: [Intents.FLAGS.GUILDS] });
-let DISCORD_CLIENT_READY = false;
-export async function initializeDiscordClient() {
-    // Login to Discord with your client's token
-    discordClient.login(); // This leaves the app blocking
-    // because it opens a ws connection to Discord,
-    // call discordClient.destroy() somewhere else to close it (if required)
-
-    // When the client is ready, run this code (only once)
-    discordClient.once("ready", async () => {
-        console.log("discord client is ready");
-        DISCORD_CLIENT_READY = true;
-    });
-}
-
 export async function postDailyMessages() {
-    if (!DISCORD_CLIENT_READY) {
-        console.error("discord client is not ready");
-        return;
-    }
-
+    const client = await getDiscordClient();
     console.log("postDailyMessages triggered at:", new Date(Date.now()).toUTCString(0));
-    const leetcode = new Leetcode(discordClient);
+
+    const leetcode = new Leetcode(client);
     await leetcode.postDailyChallenge();
     await leetcode.postWeeklyChallenge();
 
-    const stats = new Stats(discordClient);
+    const stats = new Stats(client);
     await stats.postDailyStats();
+    client.destroy();
 }
 
 export async function postWeeklyMessages() {
-    if (!DISCORD_CLIENT_READY) {
-        console.error("discord client is not ready");
-        return;
-    }
+    const client = await getDiscordClient();
 
     console.log("postWeeklyMessages triggered at:", new Date(Date.now()).toUTCString(0));
-    const stats = new Stats(discordClient);
+    const stats = new Stats(client);
     await stats.postWeeklyStats();
+    client.destroy();
 }


### PR DESCRIPTION
https://github.com/kajahno/elprimobot/pull/50 Moving the singleton part to its own PR - This will make stats changes easier to review.

Tested these changes manually, this is what's included:

* Fixes https://github.com/kajahno/elprimobot/issues/40
* Moving Discord Initialization to its own file
* Handles concurrency by returning an existing client if it's already created
* We have events running daily and weekly, I added a new line to destroy the client after the work is done, this will remove any memory leaks due to keeping connections open to discord while they're not needed.



