### PR TITLE
Return 1 week's inactivity when prev week is not found

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -93,10 +93,6 @@ export class Stats {
         const mostRecentWeeklyMessage = [...messages.values()].reverse().find((m) => m.author.username === "elprimobot"
             && m.content.indexOf("Weekly") > -1);
 
-        if (!mostRecentWeeklyMessage) {
-            return [stats, null];
-        }
-
         const [active, oneWeekInactive] = Stats._getActivityFromStats(stats);
         const activeSeen = new Set(active);
         const getInactive = (field) => {
@@ -121,9 +117,9 @@ export class Stats {
             });
         }
 
-        const prevEmbedUpdate = mostRecentWeeklyMessage.embeds[0];
+        const prevEmbedUpdate = mostRecentWeeklyMessage?.embeds[0];
         if (!prevEmbedUpdate) {
-            // no weekly updates
+            // when there is no previous weekly update, default to this week's inactivity
             return [
                 active,
                 inactiveMsg,


### PR DESCRIPTION
Since we didn't have updates for a few weeks - the bot wouldn't fine the most recent weekly update, this fixes that issue.