### PR TITLE
feature/onlyweekly: Removing daily and computing weekly

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -82,15 +82,19 @@ export class Stats {
     /**
      * Evaluates user activity over the weeks
      * we rely on the latest weekly update from the bot
+     * if none is found, we pardon everyone and start from scratch
      * @param {*} stats this weeks stats
      * @returns users inactity over the past few weeks
      */
     _processInactivityWeeks = async (stats) => {
-        const twoWeeksAgo = getSnowflakeFromDay(-14);
+        // weekly update will be within the last 8 days
+        const lastWeekAgo = getSnowflakeFromDay(-8);
         const statsChannel = await this._getStatsChannel();
-        const messages = await statsChannel.messages.fetch({ limit: 100, after: twoWeeksAgo });
+        const messages = await statsChannel.messages.fetch({ limit: 1000, after: lastWeekAgo });
 
-        const mostRecentWeeklyMessage = [...messages.values()].reverse().find((m) => m.author.username === "elprimobot"
+        // We want to avoid counting multiple weeks (e.g. if we sent the weekly update twice)
+        // only consider the oldest weekly update within 8 days
+        const lastWeekUpdate = [...messages.values()].find((m) => m.author.username === "elprimobot"
             && m.content.indexOf("Weekly") > -1);
 
         const [active, oneWeekInactive] = Stats._getActivityFromStats(stats);
@@ -119,7 +123,7 @@ export class Stats {
             });
         }
 
-        const prevEmbedUpdate = mostRecentWeeklyMessage?.embeds[0];
+        const prevEmbedUpdate = lastWeekUpdate?.embeds[0];
         if (!prevEmbedUpdate) {
             // when there is no previous weekly update, default to this week's inactivity
             return [
@@ -164,83 +168,28 @@ export class Stats {
     };
 
     /**
-     * Weekly stats are calculated based on previous daily stats
-     * this only considers the bot update for each day
-     * @returns stats for all the users
-     */
-    _computeWeeklyStats = async () => {
-        const sevenDaysAgo = getSnowflakeFromDay(-7);
-        const statsChannel = await this._getStatsChannel();
-        const stats = await Stats._initStats(statsChannel.guild);
-
-        const messages = await statsChannel.messages.fetch({ limit: 100, after: sevenDaysAgo });
-        const collectedDays = new Set();
-
-        logger.debug("getting weekly stats from channels");
-
-        for (const message of messages.values()) {
-            const isBot = message.author.username === "elprimobot";
-            const isDaily = message.content.indexOf("Daily") > -1;
-            const day = new Date(message.createdTimestamp);
-            const key = `${day.getDay()}/${day.getMonth()}/${day.getFullYear()}`;
-            // we only take the latest stat posted for the bot that day
-            if (!isBot || !isDaily || collectedDays.has(key)) {
-                continue;
-            }
-            collectedDays.add(key);
-
-            const { fields } = message.embeds[0];
-            const statRows = fields[0].value.split("\n");
-            for (let row of statRows) {
-                // "[firstName] [lastName] (5 | 50 | 2500)"
-                // remove any bold
-                row = row.replaceAll("*", "");
-                let [username, values] = row.split("(");
-                if (!username || !values) {
-                    // we couldn"t parse
-                    break;
-                }
-                // clean input
-                username = username.trim();
-                values = values.replaceAll(" ", "").replaceAll(")", "");
-
-                const [posts, words, letters] = values.split("|");
-                if (Number.isNaN(Number(posts))
-                    || Number.isNaN(Number(words))
-                    || Number.isNaN(Number(letters))) {
-                    // we couldn't parse
-                    break;
-                }
-                stats[username] = stats[username] || Stats._defaultStats();
-                stats[username].posts += Number(posts);
-                stats[username].words += Number(words);
-                stats[username].letters += Number(letters);
-            }
-        }
-        logger.debug("done getting weekly stats from channels");
-        return stats;
-    };
-
-    /**
-    * Daily stats are calculated based on the activity of each user for last 24hours
+    * Compute all the message from a given date
+    * this has to be a snowflake date
     * @returns stats for all the users
     */
-    _computeDailyStats = async () => {
+    _computeStatsFromDate = async (snowflakeFromDate) => {
         const dominationGuild = this.client.guilds.resolve(config.GUILD_ID);
         const channels = await dominationGuild.channels.fetch();
         const stats = await Stats._initStats(dominationGuild);
-
-        const oneDayAgo = getSnowflakeFromDay(-1);
 
         for (const channel of channels.values()) {
             if (channel.type !== "GUILD_TEXT") {
                 logger.debug(`skipping channel ${channel.name}, type: ${channel.type}`);
                 continue;
             }
+            // Discord limits the number of messages we can fetch at once
+            // We will have to fetch all the messages until we reach the last 7 days
+            // TODO: get back here
+            // limit: int value should be less than or equal to 100.
             const numMessages = 100;
             const messages = await channel.messages.fetch({
                 limit: numMessages,
-                after: oneDayAgo,
+                after: snowflakeFromDate,
             });
 
             logger.silly(`reading the most recent ${numMessages} from channel ${channel.name}`);
@@ -280,20 +229,9 @@ export class Stats {
         }
 
         const statsChannel = await this._getStatsChannel();
+        logger.debug(message);
         await statsChannel.send({ content: title, embeds: [message] });
         logger.debug(`sent stats to channel ${config.STATS_CHANNEL}`);
-    };
-
-    /*
-        Collects all the messages in the last 24 hours and posts daily stats
-    */
-    postDailyStats = async () => {
-        const stats = await this._computeDailyStats();
-        const [active, inactive] = Stats._getActivityFromStats(stats);
-        const inactiveMsg = inactive.length ? [{
-            name: "Inactive last 24: ", value: inactive.join(", "),
-        }] : null;
-        await this._sendStatsChannel(active, inactiveMsg, "**Daily Stats**");
     };
 
     /*
@@ -301,7 +239,8 @@ export class Stats {
         and post the weekly stats
     */
     postWeeklyStats = async () => {
-        const stats = await this._computeWeeklyStats();
+        const fromDate = getSnowflakeFromDay(-7);
+        const stats = await this._computeStatsFromDate(fromDate);
         const [onlyActive, inactiveMsg] = await this._processInactivityWeeks(stats);
         await this._sendStatsChannel(onlyActive, inactiveMsg, "**Weekly Stats**");
     };

--- a/app.js
+++ b/app.js
@@ -245,17 +245,6 @@ y.command({
     },
 });
 y.command({
-    command: "stats-daily",
-    description: "Sends Discord users daily chat activity stats",
-    handler: async () => {
-        const client = await getDiscordClient();
-        const stats = new Stats(client);
-        await stats.postDailyStats();
-        logger.info("destroying client");
-        await client.destroy();
-    },
-});
-y.command({
     command: "stats-weekly",
     description: "Sends Discord users weekly chat activity stats",
     handler: async () => {

--- a/utils.js
+++ b/utils.js
@@ -59,9 +59,6 @@ export async function postDailyMessages() {
     const leetcode = new Leetcode(client);
     await leetcode.postDailyChallenge();
     await leetcode.postWeeklyChallenge();
-
-    const stats = new Stats(client);
-    await stats.postDailyStats();
     logger.info("destroying discord client");
 }
 


### PR DESCRIPTION
- Removed daily updates
- We can only pull 100 messages at a time from discord
- Next step is to pull messages in waves until we get all the messages from the last 7 days.