### PR TITLE
Configure weeks of inactivity to remove members:

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -10,4 +10,6 @@ export const config = {
   BOTS: new Set((process.env.BOTS || 'elprimobot').split(',')),
   DAILY_MESSAGE_CRON: process.env.DAILY_MESSAGE_CRON || undefined,
   WEEKLY_MESSAGE_CRON: process.env.WEEKLY_MESSAGE_CRON || undefined,
+  INACTIVITY_WEEKS_REMOVAL: parseInt(process.env.INACTIVITY_WEEKS_REMOVAL || '8', 10),
+  INACTIVITY_WEEKS_DB_PATH: process.env.INACTIVITY_WEEKS_DB_PATH || undefined,
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,7 @@ export interface IDiscordUserStats {
   posts: number;
   words?: number;
   letters?: number;
+  lastActivity?: number; // A timestamp.
 }
 
 export interface IDiscordUserStatsActivity {
@@ -44,6 +45,11 @@ export interface IDiscordUserStatsActivity {
 export interface IDiscordUserStatsActivityMessage {
   activeUsers?: Array<IDiscordUserStats>;
   inactivityMessages: Array<EmbedField>;
+}
+
+export interface IDiscordUserStatsInactivity {
+  username: string;
+  lastActivity: number; // A timestamp.
 }
 
 // Leetcode graphql types


### PR DESCRIPTION
* Also changed the way we calculate this: we persist a small database file to check the last member activity
  * The reason was for performance improvements (also makes this feature easier to test)